### PR TITLE
Adjust install message to Package Control style

### DIFF
--- a/messages/install.txt
+++ b/messages/install.txt
@@ -1,22 +1,24 @@
 Hello!
 
-Thanks for installing this package. This package started out of some frustration
-with the lack of decent C++ plugins in Sublime Text. I figured the first step
-to improving that would make some basic snippets that can be seen as verbose for
-people to write.
+Thanks for installing this package. This package started out of some
+frustration with the lack of decent C++ plugins in Sublime Text. I figured
+the first step to improving that would make some basic snippets that can be
+seen as verbose for people to write.
 
-You're welcome to recommend any snippets in the issue page of the repository which
-can be found here: https://github.com/Rapptz/cpp-sublime-snippet/issues
+You’re welcome to recommend any snippets in the issue page of the repository
+which can be found here: https://github.com/Rapptz/cpp-sublime-snippet/issues
 
-You're also welcome to fork the snippets page and send in a pull request with your
-snippet. The only thing I ask is that you keep the style consistent with the other
-snippets.
+You’re also welcome to fork the snippets page and send in a pull request with
+your snippet. The only thing I ask is that you keep the style consistent with
+the other snippets.
 
-Documentation for the snippets can be found the reference, which can is conveniently
-here: https://github.com/Rapptz/cpp-sublime-snippet/blob/master/reference.md
+Documentation for the snippets can be found the reference, which can is
+conveniently here:
 
-If you'd like to view the reference.md file offline, you can find it under 
+https://github.com/Rapptz/cpp-sublime-snippet/blob/master/reference.md
+
+If you’d like to view the reference.md file offline, you can find it under 
 Preferences > Package Settings > C++ Snippets > View Documentation (Offline).
-It's also available on the git repository in View Documentation (Online).
+It’s also available on the git repository in View Documentation (Online).
 
 Thank you for using these snippets!


### PR DESCRIPTION
I just installed your package and noticed that Package Control displays the install message with two spaces prepended. Since you added manual line wraps at 80 characters I adjusted the newlines in such a way that the text would not look malformatted.

I also replaced the straight apostrophe with the typographically correct version.

If you’re not happy with this, that’s no deal at all. Have a nice day.