### PR TITLE
Adding snippet for main function

### DIFF
--- a/functions/main_function.sublime-snippet
+++ b/functions/main_function.sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+    <description>main(…)</description>
+    <content><![CDATA[
+int main(int argc, char const *argv[]) {
+    ${1:/* code */}
+    return 0;
+}
+]]></content>
+    <tabTrigger>main_</tabTrigger>
+    <scope>source.c, source.objc, source.c++, source.objc++</scope>
+</snippet>

--- a/functions/main_function.sublime-snippet
+++ b/functions/main_function.sublime-snippet
@@ -1,11 +1,11 @@
 <snippet>
-    <description>main(…)</description>
-    <content><![CDATA[
+	<description>main(…)</description>
+	<content><![CDATA[
 int main(int argc, char const *argv[]) {
-    ${1:/* code */}
-    return 0;
+	${1:/* code */}
+	return 0;
 }
 ]]></content>
-    <tabTrigger>main_</tabTrigger>
-    <scope>source.c, source.objc, source.c++, source.objc++</scope>
+	<tabTrigger>main_</tabTrigger>
+	<scope>source.c, source.objc, source.c++, source.objc++</scope>
 </snippet>

--- a/reference.md
+++ b/reference.md
@@ -364,6 +364,14 @@ struct has_const_iterator : decltype(has_const_iterator_impl::test<T>(0)) {};
 
 #### Regular functions
 
+**Trigger**: main_
+
+```cpp
+int main(int argc, char const *argv[]) {
+    $1
+    return 0;
+}
+```
 
 **Trigger**: funct
 


### PR DESCRIPTION
This adds a snippet for the main function to match the style of the opening bracket sitting on the same line as the function signature.

```c++
int main(int argc, char const *argv[]) {
    /* code */
    return 0;
}
```

instead of

```c++
int main(int argc, char const *argv[])
{
    /* code */
    return 0;
}
```