### PR TITLE
Fix location of menu according to the latest changes

### DIFF
--- a/messages/install.txt
+++ b/messages/install.txt
@@ -18,7 +18,7 @@ conveniently here:
 https://github.com/Rapptz/cpp-sublime-snippet/blob/master/reference.md
 
 If you’d like to view the reference.md file offline, you can find it under 
-Preferences > Package Settings > C++ Snippets > View Documentation (Offline).
+Tools > Packages > C++ Snippets > View Documentation (Offline).
 It’s also available on the git repository in View Documentation (Online).
 
 Thank you for using these snippets!


### PR DESCRIPTION
Just a little thing that popped my mind.

With version 1.3.0, the install message needs a little adjustment.
